### PR TITLE
feat: Implement core FSM logic and basic store operations

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -24,34 +24,89 @@ func NewSnapshot(rc io.ReadCloser) *Snapshot {
 	}
 }
 
-// TODO: need to impl this
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+	"github.com/tarungka/wire/internal/logger"
+)
+
+// Snapshot represents a snapshot of the database state.
+type Snapshot struct {
+	rc io.ReadCloser
+	// logger *log.Logger
+	logger zerolog.Logger
+}
+
+// NewSnapshot creates a new snapshot.
+func NewSnapshot(rc io.ReadCloser) *Snapshot {
+	return &Snapshot{
+		rc: rc,
+		// logger: log.New(log.Writer(), "[snapshot] ", log.LstdFlags),
+		logger: logger.GetLogger("snapshot"),
+	}
+}
+
 // Persist writes the snapshot to the given sink.
-func (s *Snapshot) Persist(sink raft.SnapshotSink) error {
-	defer s.rc.Close()
-	// startT := time.Now()
+func (s *Snapshot) Persist(sink raft.SnapshotSink) (retErr error) {
+	s.logger.Info().Str("sink_id", sink.ID()).Msg("starting snapshot persistence")
+	startTime := time.Now()
 
-	// cw := progress.NewCountingWriter(sink)
-	// cm := progress.StartCountingMonitor(func(n int64) {
-	// 	s.logger.Printf("persisted %d bytes", n)
-	// }, cw)
-	// n, err := func() (int64, error) {
-	// 	defer cm.StopAndWait()
-	// 	return io.Copy(cw, s.rc)
-	// }()
-	// if err != nil {
-	// 	return err
-	// }
+	// Ensure s.rc is closed. This is deferred first to catch all scenarios.
+	defer func() {
+		if err := s.rc.Close(); err != nil {
+			s.logger.Error().Err(err).Str("sink_id", sink.ID()).Msg("failed to close snapshot reader")
+			// If retErr is nil, we might want to return this error,
+			// but the primary errors are from copy and sink.Close().
+			// For now, just log it, as io.Copy or sink.Close errors are more critical.
+		}
+	}()
 
-	// dur := time.Since(startT)
-	// stats.Get(persistSize).(*expvar.Int).Set(n)
-	// stats.Get(persistDuration).(*expvar.Int).Set(dur.Milliseconds())
-	// return err
-	return nil
+	var bytesWritten int64
+	var copyErr error
+
+	bytesWritten, copyErr = io.Copy(sink, s.rc)
+
+	// Attempt to close the sink regardless of copyError.
+	// Raft expects the sink to be closed.
+	sinkCloseErr := sink.Close()
+
+	duration := time.Since(startTime)
+
+	if copyErr != nil {
+		s.logger.Error().Err(copyErr).Str("sink_id", sink.ID()).Int64("bytes_written", bytesWritten).Dur("duration_ms", duration).Msg("failed to persist snapshot")
+		// If sink.Close() also errored, log it too. copyErr takes precedence for return.
+		if sinkCloseErr != nil {
+			s.logger.Error().Err(sinkCloseErr).Str("sink_id", sink.ID()).Msg("failed to close snapshot sink after copy error")
+		}
+		return copyErr // Return the io.Copy error
+	}
+
+	// If copy was successful, check sink.Close() error.
+	if sinkCloseErr != nil {
+		s.logger.Error().Err(sinkCloseErr).Str("sink_id", sink.ID()).Int64("bytes_written", bytesWritten).Dur("duration_ms", duration).Msg("failed to close snapshot sink after successful copy")
+		return sinkCloseErr // Return the sink.Close() error
+	}
+
+	s.logger.Info().Str("sink_id", sink.ID()).Int64("bytes_written", bytesWritten).Dur("duration_ms", duration).Msg("successfully persisted snapshot")
+	return nil // Both copy and sink.Close() were successful
 }
 
 // Release releases the snapshot.
 func (s *Snapshot) Release() {
+	s.logger.Debug().Msg("snapshot release called")
 	// Ensure that the source data for the snapshot is closed regardless of
 	// whether the snapshot is persisted or not.
-	s.rc.Close()
+	// If s.rc is already closed (e.g., after Persist), closing it again
+	// might lead to an error (e.g., "file already closed").
+	// However, io.Closer interface implies that Close() should be idempotent,
+	// or at least safe to call multiple times. Standard library types like *os.File
+	// handle this. If s.rc is a custom type, it should ideally also be robust to this.
+	if err := s.rc.Close(); err != nil {
+		// Log the error, but don't propagate it as Release is a cleanup operation.
+		s.logger.Error().Err(err).Msg("error closing snapshot reader during release")
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1298,7 +1298,100 @@ func (s *Store) execute(ex *proto.ExecuteRequest) ([]*proto.ExecuteQueryResponse
 }
 
 func (s *Store) Query(qr *proto.QueryRequest) ([]*proto.QueryRows, error) {
-	return nil, ErrNotImplemented
+	if !s.open.Is() {
+		return nil, ErrStoreNotOpen
+	}
+	// Check if db is nil or closed. BadgerDB sets db to nil on Close().
+	// db.IsClosed() is another option if s.db itself is not reassigned to nil on close.
+	// Based on current fsmRestore, s.db can be nil after a close.
+	if s.db == nil {
+		s.logger.Error().Msg("database is not open or available for query")
+		return nil, ErrDatabaseNotOpen
+	}
+
+	s.logger.Debug().Interface("query_request", qr).Msg("received query request")
+
+	// For this basic implementation, we'll ignore qr.Timings, qr.Transaction, qr.Freshness, qr.Strict
+	// A full implementation would check s.isStaleRead(qr.Freshness, qr.Strict) here.
+
+	if len(qr.Statements) == 0 || qr.Statements[0] == nil || qr.Statements[0].Sql == "" {
+		s.logger.Error().Msg("empty query statement received")
+		return nil, errors.New("empty query statement")
+	}
+
+	// Assuming one statement for basic GET query
+	stmtStr := qr.Statements[0].Sql
+	parts := strings.Fields(stmtStr)
+
+	if len(parts) != 2 || strings.ToUpper(parts[0]) != "GET" {
+		err := fmt.Errorf("unsupported query statement, expected 'GET <key>', got: %s", stmtStr)
+		s.logger.Error().Err(err).Str("statement", stmtStr).Msg("parsing query statement")
+		return nil, err
+	}
+	queryKey := parts[1]
+
+	var resultRows []*proto.QueryRows
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(queryKey))
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				s.logger.Info().Str("key", queryKey).Msg("key not found during query")
+				// Return empty result set, not an error
+				resultRows = []*proto.QueryRows{
+					{
+						Columns: []string{"key", "value"},
+						Types:   []string{"text", "text"},
+						Values:  make([]*proto.RowValue, 0), // Empty values
+					},
+				}
+				return nil // Key not found is not a failure for the View operation itself for this query type
+			}
+			s.logger.Error().Err(err).Str("key", queryKey).Msg("failed to get key from database")
+			return fmt.Errorf("database access error for key %s: %w", queryKey, err)
+		}
+
+		// Key found, retrieve its value
+		var valueBytes []byte
+		err = item.Value(func(val []byte) error {
+			valueBytes = append([]byte{}, val...)
+			return nil
+		})
+		if err != nil {
+			s.logger.Error().Err(err).Str("key", queryKey).Msg("failed to retrieve value for key")
+			return fmt.Errorf("retrieve value for key %s: %w", queryKey, err)
+		}
+
+		s.logger.Debug().Str("key", queryKey).Bytes("value", valueBytes).Msg("key found with value")
+
+		// Construct the result
+		// Key Datum
+		keyDatum := &proto.Datum{Value: &proto.Datum_S{S: queryKey}}
+		// Value Datum - store as bytes (blob)
+		valueDatum := &proto.Datum{Value: &proto.Datum_B{B: valueBytes}}
+
+		row := &proto.RowValue{
+			Values: []*proto.Datum{keyDatum, valueDatum},
+		}
+
+		resultRows = []*proto.QueryRows{
+			{
+				Columns: []string{"key", "value"},
+				Types:   []string{"text", "blob"}, // Value is effectively a blob
+				Values:  []*proto.RowValue{row},
+			},
+		}
+		return nil
+	})
+
+	if err != nil {
+		// This error is from the s.db.View transaction itself (e.g., failed to start txn)
+		// or an error returned from within the txn func that wasn't badger.ErrKeyNotFound.
+		s.logger.Error().Err(err).Msg("query execution failed")
+		return nil, err
+	}
+
+	s.logger.Info().Str("key", queryKey).Int("num_results", len(resultRows)).Msg("query executed successfully")
+	return resultRows, nil
 }
 
 func (s *Store) Request(eqr *commandProto.ExecuteQueryRequest) ([]*commandProto.ExecuteQueryResponse, error) {
@@ -1466,12 +1559,210 @@ func (s *Store) load(lr *proto.LoadRequest) error {
 // with Apply, as it states Apply() and Snapshot() are always called from the same
 // thread.
 func (s *Store) fsmSnapshot() (fSnap raft.FSMSnapshot, retErr error) {
-	return nil, ErrNotImplemented
+	fsmIndex := s.fsmIdx.Load()
+	fsmTerm := s.fsmTerm.Load()
+
+	s.logger.Info().Uint64("index", fsmIndex).Uint64("term", fsmTerm).Msg("starting FSM snapshot")
+	stats.Add(numSnapshots, 1) // Increment snapshot count
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		// Ensure pipeWriter is closed. If an error occurs, CloseWithError will be called.
+		// If successful, this Close will signal EOF to the reader.
+		defer pipeWriter.Close()
+
+		// bufio.Writer for potentially more efficient writes, especially for small metadata writes.
+		// For s.db.Backup, it might manage its own buffering, but using it here is consistent.
+		bufioWriter := bufio.NewWriter(pipeWriter)
+
+		// Write FSM index (8 bytes)
+		indexBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(indexBytes, fsmIndex)
+		if _, err := bufioWriter.Write(indexBytes); err != nil {
+			s.logger.Error().Err(err).Msg("failed to write FSM index to snapshot pipe")
+			pipeWriter.CloseWithError(fmt.Errorf("write fsm index: %w", err))
+			stats.Add(numSnapshotsFailed, 1)
+			return
+		}
+
+		// Write FSM term (8 bytes)
+		termBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(termBytes, fsmTerm)
+		if _, err := bufioWriter.Write(termBytes); err != nil {
+			s.logger.Error().Err(err).Msg("failed to write FSM term to snapshot pipe")
+			pipeWriter.CloseWithError(fmt.Errorf("write fsm term: %w", err))
+			stats.Add(numSnapshotsFailed, 1)
+			return
+		}
+
+		// Flush metadata to ensure it's written before the backup starts
+		if err := bufioWriter.Flush(); err != nil {
+			s.logger.Error().Err(err).Msg("failed to flush metadata to snapshot pipe")
+			pipeWriter.CloseWithError(fmt.Errorf("flush metadata: %w", err))
+			stats.Add(numSnapshotsFailed, 1)
+			return
+		}
+
+		// Stream the BadgerDB backup. since=0 means a full backup.
+		// s.db.Backup itself writes to the provided writer.
+		startTime := time.Now()
+		if err := s.db.Backup(bufioWriter, 0); err != nil {
+			s.logger.Error().Err(err).Msg("failed to backup database to snapshot pipe")
+			pipeWriter.CloseWithError(fmt.Errorf("backup database: %w", err))
+			stats.Add(numSnapshotsFailed, 1)
+			return
+		}
+
+		// Final flush to ensure all data from bufioWriter is written to pipeWriter.
+		// s.db.Backup should ideally flush its own data, but an extra flush here doesn't hurt.
+		if err := bufioWriter.Flush(); err != nil {
+			s.logger.Error().Err(err).Msg("failed to flush database backup to snapshot pipe")
+			pipeWriter.CloseWithError(fmt.Errorf("flush database backup: %w", err))
+			stats.Add(numSnapshotsFailed, 1)
+			return
+		}
+
+		s.logger.Info().Uint64("index", fsmIndex).Uint64("term", fsmTerm).Dur("duration_ms", time.Since(startTime)).Msg("successfully wrote FSM snapshot to pipe")
+	}()
+
+	return snapshot.NewSnapshot(pipeReader), nil
 }
 
 // TODO: implementation is not complete
 func (s *Store) fsmApply(l *raft.Log) (e interface{}) {
-	return ErrNotImplemented
+	s.fsmIdx.Store(l.Index)
+	s.fsmTerm.Store(l.Term)
+	s.fsmUpdateTime.Store(time.Now()) // Record FSM update time.
+
+	var cmd commandProto.Command
+	if err := command.Unmarshal(l.Data, &cmd); err != nil {
+		s.logger.Error().Err(err).Msg("failed to unmarshal command")
+		return &fsmExecuteQueryResponse{error: fmt.Errorf("unmarshal command: %w", err)}
+	}
+
+	// Note: Decompression of cmd.SubCommand is handled by functions like
+	// command.UnmarshalExecuteRequest if cmd.Compressed is true.
+	// If a command type is processed here that doesn't use such a helper,
+	// and cmd.Compressed is true, manual decompression would be needed.
+
+	switch cmd.Type {
+	case commandProto.Command_COMMAND_TYPE_EXECUTE:
+		var ex commandProto.ExecuteRequest
+		// command.UnmarshalExecuteRequest is assumed to handle decompression if cmd.Compressed is true.
+		if err := command.UnmarshalExecuteRequest(&ex, cmd.SubCommand, cmd.Compressed); err != nil {
+			s.logger.Error().Err(err).Msg("failed to unmarshal execute request")
+			return &fsmExecuteQueryResponse{error: fmt.Errorf("unmarshal execute request: %w", err)}
+		}
+
+		if len(ex.Statements) == 0 {
+			s.logger.Error().Msg("no statements found in ExecuteRequest")
+			return &fsmExecuteQueryResponse{error: errors.New("no statements found in ExecuteRequest")}
+		}
+		// As per requirement, assume one statement for SET/DELETE FSM.
+		// For other operations, multiple statements might be valid but not for this FSM's scope.
+		if len(ex.Statements) > 1 {
+			s.logger.Warn().Int("statements_count", len(ex.Statements)).Msg("multiple statements received, but FSM handles one for SET/DELETE")
+			// Continue with the first statement for SET/DELETE, or return error if strict one-statement policy is desired.
+			// For this implementation, we'll process only the first one if it's SET/DELETE.
+		}
+		stmtStr := ex.Statements[0].Sql
+
+		parts := strings.Fields(stmtStr)
+		if len(parts) == 0 {
+			s.logger.Error().Msg("empty statement string")
+			return &fsmExecuteQueryResponse{error: errors.New("empty statement string")}
+		}
+
+		resp := &fsmExecuteQueryResponse{results: make([]*commandProto.ExecuteQueryResponse, 1)}
+		resp.results[0] = &commandProto.ExecuteQueryResponse{}
+
+		op := strings.ToUpper(parts[0])
+		switch op {
+		case "SET":
+			if len(parts) < 2 { // Must have SET <key> at least
+				err := errors.New("invalid SET format. Expected SET <key> [<value>]")
+				s.logger.Error().Err(err).Str("statement", stmtStr).Msg("parsing SET statement")
+				resp.error = err
+				return resp
+			}
+			key := parts[1]
+			value := ""
+			if len(parts) > 2 {
+				value = strings.Join(parts[2:], " ")
+			}
+
+			err := s.db.Update(func(txn *badger.Txn) error {
+				s.logger.Debug().Str("key", key).Str("value", value).Msg("executing SET")
+				return txn.Set([]byte(key), []byte(value))
+			})
+			if err != nil {
+				s.logger.Error().Err(err).Str("key", key).Msg("failed to SET key")
+				resp.error = err
+				return resp
+			}
+			resp.results[0].LastInsertId = 0 // Not applicable for SET
+			resp.results[0].RowsAffected = 1
+		case "DELETE":
+			if len(parts) != 2 { // Must be DELETE <key> exactly
+				err := errors.New("invalid DELETE format. Expected DELETE <key>")
+				s.logger.Error().Err(err).Str("statement", stmtStr).Msg("parsing DELETE statement")
+				resp.error = err
+				return resp
+			}
+			key := parts[1]
+			err := s.db.Update(func(txn *badger.Txn) error {
+				s.logger.Debug().Str("key", key).Msg("executing DELETE")
+				// BadgerDB's Delete is idempotent. It doesn't error if key not found.
+				// To accurately report RowsAffected, one might check existence first,
+				// but that's usually not done for performance reasons unless required.
+				return txn.Delete([]byte(key))
+			})
+			if err != nil {
+				s.logger.Error().Err(err).Str("key", key).Msg("failed to DELETE key")
+				resp.error = err
+				return resp
+			}
+			// BadgerDB doesn't directly return "rows affected" for delete in a way SQL does.
+			// We assume success means 1 row affected if it existed, or 0 if it didn't.
+			// For simplicity, and common KV behavior, we can claim 1 if no error.
+			// A more accurate RowsAffected would require a pre-check or different DB API.
+			resp.results[0].RowsAffected = 1
+		default:
+			err := fmt.Errorf("unrecognized statement type in EXECUTE: %s", op)
+			s.logger.Error().Err(err).Str("statement", stmtStr).Msg("parsing EXECUTE statement")
+			resp.error = err
+			return resp
+		}
+		return resp
+
+	case commandProto.Command_COMMAND_TYPE_LOAD:
+		s.logger.Info().Msg("fsmApply: LOAD command received. This type should typically be handled by fsmRestore.")
+		// LOAD implies a full database state replacement. If it reaches fsmApply,
+		// it suggests a misunderstanding of its role or a very specific incremental load protocol.
+		// For a general FSM, fsmRestore is the place for snapshot loading.
+		return &fsmExecuteQueryResponse{error: ErrNotImplemented}
+
+	case commandProto.Command_COMMAND_TYPE_NOOP:
+		s.logger.Debug().Msg("fsmApply: NOOP command")
+		return &fsmExecuteQueryResponse{} // Success, no error, no results
+
+	case commandProto.Command_COMMAND_TYPE_QUERY:
+		s.logger.Warn().Msg("fsmApply: QUERY command received. Read-only commands should not typically pass through fsmApply.")
+		// Queries are read-only and don't change FSM state.
+		// If it's here, it's likely an error in routing or command design for Raft.
+		return &fsmExecuteQueryResponse{error: fmt.Errorf("QUERY command type should not be applied to FSM state")}
+	
+	case commandProto.Command_COMMAND_TYPE_EXECUTE_QUERY:
+		s.logger.Warn().Msg("fsmApply: EXECUTE_QUERY command received. Complex queries with potential state changes not supported by this simple FSM.")
+		// EXECUTE_QUERY might modify state and return results.
+		// This FSM only handles simple SET/DELETE via EXECUTE.
+		return &fsmExecuteQueryResponse{error: ErrNotImplemented}
+
+	default:
+		s.logger.Error().Str("command_type", cmd.Type.String()).Msg("unhandled command type in fsmApply")
+		return &fsmExecuteQueryResponse{error: fmt.Errorf("unhandled command type: %s", cmd.Type.String())}
+	}
 }
 
 // TODO: implementation is not complete
@@ -1479,14 +1770,142 @@ func (s *Store) fsmApply(l *raft.Log) (e interface{}) {
 // will not be called concurrently with Apply(), so synchronization with Execute()
 // is not necessary.
 func (s *Store) fsmRestore(rc io.ReadCloser) (retErr error) {
+	startTime := time.Now()
+	s.logger.Info().Str("node_id", s.raftID).Msg("initiating FSM restore from snapshot")
+
 	defer func() {
+		if errClose := rc.Close(); errClose != nil {
+			s.logger.Error().Err(errClose).Msg("failed to close snapshot reader during fsmRestore cleanup")
+			if retErr == nil {
+				// Only assign if no primary error occurred during restore itself.
+				retErr = fmt.Errorf("close snapshot reader: %w", errClose)
+			}
+		}
 		if retErr != nil {
-			// stats.Add(numRestoresFailed, 1)
+			stats.Add(numRestoresFailed, 1)
+			s.logger.Error().Err(retErr).Str("node_id", s.raftID).Dur("duration_ms", time.Since(startTime)).Msg("FSM restore failed")
+		} else {
+			stats.Add(numRestores, 1)
+			s.logger.Info().Str("node_id", s.raftID).Dur("duration_ms", time.Since(startTime)).Msg("FSM restore completed successfully")
+		}
+	}()
+
+	bufReader := bufio.NewReader(rc)
+
+	// Read FSM index (8 bytes)
+	indexBytes := make([]byte, 8)
+	if _, err := io.ReadFull(bufReader, indexBytes); err != nil {
+		retErr = fmt.Errorf("read fsm index from snapshot: %w", err)
+		return // Defer will log and update stats
+	}
+	restoredIndex := binary.BigEndian.Uint64(indexBytes)
+
+	// Read FSM term (8 bytes)
+	termBytes := make([]byte, 8)
+	if _, err := io.ReadFull(bufReader, termBytes); err != nil {
+		retErr = fmt.Errorf("read fsm term from snapshot: %w", err)
+		return // Defer will log and update stats
+	}
+	restoredTerm := binary.BigEndian.Uint64(termBytes)
+	s.logger.Info().Uint64("index", restoredIndex).Uint64("term", restoredTerm).Msg("FSM metadata read from snapshot")
+
+	// Define the database path
+	dbPath := filepath.Join(s.raftDir, "badgerdb")
+	if s.dbDir != "" { // Prefer s.dbDir if it was explicitly set (e.g. from config)
+		dbPath = s.dbDir
+	} else {
+		s.logger.Warn().Str("default_db_path", dbPath).Msg("s.dbDir is not set, using default path derived from raftDir for BadgerDB. Ensure this is intended.")
+	}
+
+
+	// Close the current database instance, if open.
+	if s.db != nil {
+		s.logger.Info().Str("db_path", s.db.Opts().Dir).Msg("closing current database instance for restore")
+		if err := s.db.Close(); err != nil {
+			// Log error, but proceed with removal as the directory needs to be replaced.
+			s.logger.Error().Err(err).Str("db_path", s.db.Opts().Dir).Msg("failed to close current database instance; proceeding with removal")
+		}
+		s.db = nil // Ensure s.db is nil so Open creates a new one
+	}
+
+	// Remove the existing database directory.
+	s.logger.Info().Str("db_path", dbPath).Msg("removing existing database directory for restore")
+	if err := os.RemoveAll(dbPath); err != nil {
+		retErr = fmt.Errorf("remove existing database directory %s: %w", dbPath, err)
+		return // Defer will log and update stats
+	}
+
+	// Ensure the database directory exists before opening.
+	if err := os.MkdirAll(dbPath, 0755); err != nil {
+		retErr = fmt.Errorf("create database directory %s: %w", dbPath, err)
+		return // Defer will log and update stats
+	}
+
+	// Re-open the database.
+	s.logger.Info().Str("db_path", dbPath).Msg("re-opening database for restore")
+	var errOpen error
+	s.db, errOpen = db.Open(dbPath) // db.Open is from "github.com/tarungka/wire/internal/db"
+	if errOpen != nil {
+		retErr = fmt.Errorf("re-open database at %s: %w", dbPath, errOpen)
+		return // Defer will log and update stats
+	}
+	s.logger.Info().Str("db_path", dbPath).Msg("database re-opened successfully")
+
+	// Load the snapshot data into the database.
+	// The bufReader now points to the beginning of the BadgerDB backup stream.
+	// Using MaxPendingWrites = 100 as a typical value for badger.Load.
+	// badger.DefaultDBLoadingMode might not be a constant, so use an explicit value or check BadgerDB docs.
+	// Let's assume a reasonable value for MaxPendingWrites, e.g., 100 or 256.
+	s.logger.Info().Msg("loading database from snapshot stream")
+	if err := s.db.Load(bufReader, 256); err != nil {
+		retErr = fmt.Errorf("load database from snapshot: %w", err)
+		return // Defer will log and update stats
+	}
+
+	// Update FSM state.
+	s.fsmIdx.Store(restoredIndex)
+	s.fsmTerm.Store(restoredTerm)
+	s.fsmUpdateTime.Store(time.Now())
+
+	// Success, retErr remains nil. Defer will log success and update stats.
+	return
+}
+
+// TODO: implementation is not complete
+// fsmRestore restores the node to a previous state. The Hashicorp docs state this
+// will not be called concurrently with Apply(), so synchronization with Execute()
+// is not necessary.
+func (s *Store) fsmRestore_backup(rc io.ReadCloser) (retErr error) {
+	s.fsmUpdateTime.Store(time.Now()) // Record FSM update time on restore as well.
+	defer func() {
+		if errClose := rc.Close(); errClose != nil {
+			s.logger.Error().Err(errClose).Msg("failed to close reader in fsmRestore")
+			if retErr == nil {
+				retErr = errClose
+			}
+		}
+		if retErr != nil {
+			stats.Add(numRestoresFailed, 1)
+		} else {
+			stats.Add(numRestores, 1)
 		}
 	}()
 	s.logger.Printf("initiating node restore on node ID %s", s.raftID)
 
-	return nil
+	// The actual restore logic is complex and involves replacing the database.
+	// For this task, we are primarily focused on fsmApply.
+	// A full fsmRestore implementation would involve:
+	// 1. Reading the snapshot data from 'rc'.
+	// 2. Potentially deserializing it (e.g., if it's a BadgerDB backup stream).
+	// 3. Replacing the contents of s.db with this snapshot.
+	//    - This might involve closing the current s.db, loading data into a new DB instance,
+	//      and then replacing s.db with the new instance, or using DB-specific load/restore functions.
+	// 4. After successfully restoring, Raft core updates FSM index/term from snapshot metadata.
+	s.logger.Info().Msg("fsmRestore: Actual database restoration from snapshot stream is not implemented in this scope.")
+	
+	// For now, returning ErrNotImplemented to signify that the DB restore part is missing.
+	retErr = ErrNotImplemented 
+	return retErr
 
 	// startT := time.Now()
 	// // Create a scatch file to write the restore data to.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,507 @@
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/hashicorp/raft"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarungka/wire/internal/command"
+	commandProto "github.com/tarungka/wire/internal/command/proto"
+	"github.com/tarungka/wire/internal/db"
+	"github.com/tarungka/wire/internal/logger"
+	"github.com/tarungka/wire/internal/rsync"
+)
+
+// testSink implements raft.SnapshotSink for testing.
+type testSink struct {
+	*bytes.Buffer
+	id     string
+	closed bool
+}
+
+func newTestSink(id string) *testSink {
+	return &testSink{
+		Buffer: new(bytes.Buffer),
+		id:     id,
+	}
+}
+
+func (t *testSink) ID() string {
+	return t.id
+}
+
+func (t *testSink) Close() error {
+	if t.closed {
+		return fmt.Errorf("sink already closed")
+	}
+	t.closed = true
+	return nil
+}
+
+func (t *testSink) Cancel() error {
+	t.closed = true
+	return nil
+}
+
+// newTestStore creates a new Store for testing.
+// It returns the store and a cleanup function.
+func newTestStore(t *testing.T, useMemDB bool) (*Store, func()) {
+	t.Helper()
+
+	raftDir := t.TempDir()
+
+	var testDB *badger.DB
+	var dbPath string
+	var err error
+
+	if useMemDB {
+		testDB, err = db.OpenInMemory()
+		require.NoError(t, err, "failed to open in-memory db")
+	} else {
+		dbPath = t.TempDir()
+		testDB, err = db.Open(dbPath)
+		require.NoError(t, err, "failed to open db at %s", dbPath)
+	}
+
+	// Suppress verbose logging during tests unless explicitly needed.
+	// log := logger.New(logger.Pretty, zerolog.Disabled) // Or zerolog.ErrorLevel for errors only
+	log := logger.GetLogger("store_test")
+	log = log.Level(zerolog.ErrorLevel) // Reduce noise during tests
+
+	s := &Store{
+		open:            rsync.NewAtomicBool(),
+		raftDir:         raftDir,
+		logger:          log,
+		db:              testDB,
+		dbDir:           dbPath, // Store the dbPath if not in-memory
+		reqMarshaller:   command.NewRequestMarshaler(),
+		fsmIdx:          &atomic.Uint64{},
+		fsmTerm:         &atomic.Uint64{},
+		fsmUpdateTime:   rsync.NewAtomicTime(),
+		numNoops:        &atomic.Uint64{},
+		numSnapshots:    &atomic.Uint64{},
+		ApplyTimeout:    1 * time.Second, // Shorter timeout for tests
+		readyChans:      rsync.NewReadyChannels(),
+		notifyingNodes:  make(map[string]*Server),
+		leaderObservers: make([]chan<- struct{}, 0),
+	}
+	s.open.Set() // Simulate store being open for FSM methods directly
+
+	cleanup := func() {
+		if s.db != nil && !s.db.IsClosed() {
+			err := s.db.Close()
+			assert.NoError(t, err, "error closing test db")
+		}
+		// Raft dir cleanup is handled by t.TempDir()
+		// If db was file-based, its t.TempDir() also handles cleanup.
+	}
+
+	return s, cleanup
+}
+
+func TestStore_FSMApply_Set(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	key := "testkey"
+	value := "testvalue"
+	stmt := fmt.Sprintf("SET %s %s", key, value)
+
+	cmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: stmt}}}),
+	}
+	logData, err := command.Marshal(cmd)
+	require.NoError(t, err)
+
+	raftLog := &raft.Log{
+		Index: 1,
+		Term:  1,
+		Data:  logData,
+	}
+
+	resp := s.fsmApply(raftLog)
+	require.NotNil(t, resp)
+	fsmResp, ok := resp.(*fsmExecuteQueryResponse)
+	require.True(t, ok, "response is not of type *fsmExecuteQueryResponse")
+
+	assert.NoError(t, fsmResp.error)
+	require.Len(t, fsmResp.results, 1)
+	assert.Equal(t, int64(1), fsmResp.results[0].GetRowsAffected())
+
+	assert.Equal(t, uint64(1), s.fsmIdx.Load())
+	assert.Equal(t, uint64(1), s.fsmTerm.Load())
+	assert.NotZero(t, s.fsmUpdateTime.Load())
+
+	// Verify data in DB
+	err = s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(key))
+		require.NoError(t, err)
+		val, err := item.ValueCopy(nil)
+		require.NoError(t, err)
+		assert.Equal(t, value, string(val))
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestStore_FSMApply_Delete(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	key := "testkeydel"
+	value := "testvaluedel"
+
+	// 1. SET the key first
+	setStmt := fmt.Sprintf("SET %s %s", key, value)
+	setCmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: setStmt}}}),
+	}
+	setLogData, err := command.Marshal(setCmd)
+	require.NoError(t, err)
+	setRaftLog := &raft.Log{Index: 1, Term: 1, Data: setLogData}
+	s.fsmApply(setRaftLog) // Apply SET
+
+	// 2. DELETE the key
+	delStmt := fmt.Sprintf("DELETE %s", key)
+	delCmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: delStmt}}}),
+	}
+	delLogData, err := command.Marshal(delCmd)
+	require.NoError(t, err)
+
+	delRaftLog := &raft.Log{
+		Index: 2, // Next index
+		Term:  1,
+		Data:  delLogData,
+	}
+
+	resp := s.fsmApply(delRaftLog)
+	require.NotNil(t, resp)
+	fsmResp, ok := resp.(*fsmExecuteQueryResponse)
+	require.True(t, ok)
+
+	assert.NoError(t, fsmResp.error)
+	require.Len(t, fsmResp.results, 1)
+	assert.Equal(t, int64(1), fsmResp.results[0].GetRowsAffected()) // Badger Delete is idempotent
+
+	assert.Equal(t, uint64(2), s.fsmIdx.Load())
+	assert.Equal(t, uint64(1), s.fsmTerm.Load())
+
+	// Verify data is deleted from DB
+	err = s.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get([]byte(key))
+		assert.ErrorIs(t, err, badger.ErrKeyNotFound)
+		return nil
+	})
+	require.NoError(t, err) // View itself should not error
+}
+
+func TestStore_FSMApply_InvalidStatement(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	stmt := "INVALIDCMD foo bar"
+	cmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: stmt}}}),
+	}
+	logData, err := command.Marshal(cmd)
+	require.NoError(t, err)
+
+	raftLog := &raft.Log{Index: 1, Term: 1, Data: logData}
+
+	resp := s.fsmApply(raftLog)
+	require.NotNil(t, resp)
+	fsmResp, ok := resp.(*fsmExecuteQueryResponse)
+	require.True(t, ok)
+
+	assert.Error(t, fsmResp.error)
+	assert.Contains(t, fsmResp.error.Error(), "unrecognized statement type in EXECUTE: INVALIDCMD")
+
+	assert.Equal(t, uint64(1), s.fsmIdx.Load()) // Index/term still updated
+	assert.Equal(t, uint64(1), s.fsmTerm.Load())
+}
+
+func TestStore_FSMApply_Noop(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	cmd := &commandProto.Command{Type: commandProto.Command_COMMAND_TYPE_NOOP}
+	logData, err := command.Marshal(cmd)
+	require.NoError(t, err)
+
+	raftLog := &raft.Log{Index: 5, Term: 2, Data: logData}
+
+	resp := s.fsmApply(raftLog)
+	require.NotNil(t, resp)
+	fsmResp, ok := resp.(*fsmExecuteQueryResponse)
+	require.True(t, ok)
+
+	assert.NoError(t, fsmResp.error)
+	assert.Empty(t, fsmResp.results) // NOOP has no results
+
+	assert.Equal(t, uint64(5), s.fsmIdx.Load())
+	assert.Equal(t, uint64(2), s.fsmTerm.Load())
+}
+
+func TestStore_FSMApply_Unimplemented(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	// Using QUERY type which is not meant to modify state via fsmApply directly
+	cmd := &commandProto.Command{
+		Type: commandProto.Command_COMMAND_TYPE_QUERY,
+		SubCommand: command.MustMarshal(&commandProto.QueryRequest{
+			Statements: []*commandProto.Statement{{Sql: "GET foo"}},
+		}),
+	}
+	logData, err := command.Marshal(cmd)
+	require.NoError(t, err)
+
+	raftLog := &raft.Log{Index: 1, Term: 1, Data: logData}
+
+	resp := s.fsmApply(raftLog)
+	require.NotNil(t, resp)
+	fsmResp, ok := resp.(*fsmExecuteQueryResponse)
+	require.True(t, ok)
+
+	assert.ErrorIs(t, fsmResp.error, ErrNotImplemented) // Changed to ErrNotImplemented based on fsmApply logic
+	assert.Contains(t, fsmResp.error.Error(), "QUERY command type should not be applied to FSM state")
+
+
+	assert.Equal(t, uint64(1), s.fsmIdx.Load()) // Index/term updated
+	assert.Equal(t, uint64(1), s.fsmTerm.Load())
+}
+
+func TestStore_FSMInteraction_SnapshotAndPersist(t *testing.T) {
+	s, cleanup := newTestStore(t, false) // Use file-based DB for snapshot/restore
+	defer cleanup()
+
+	// 1. Set some data
+	s.fsmIdx.Store(10) // Simulate prior logs
+	s.fsmTerm.Store(2)
+	key, value := "snapkey", "snapvalue"
+	setStmt := fmt.Sprintf("SET %s %s", key, value)
+	setCmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: setStmt}}}),
+	}
+	setLogData, err := command.Marshal(setCmd)
+	require.NoError(t, err)
+	setRaftLog := &raft.Log{Index: 11, Term: 2, Data: setLogData} // Apply this log
+	applyResp := s.fsmApply(setRaftLog)
+	fsmApplyResp, _ := applyResp.(*fsmExecuteQueryResponse)
+	require.NoError(t, fsmApplyResp.error)
+
+
+	// 2. Call fsmSnapshot
+	fsmSnap, err := s.fsmSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, fsmSnap)
+
+	// 3. Persist to testSink
+	sink := newTestSink("test-snapshot-1")
+	err = fsmSnap.Persist(sink)
+	require.NoError(t, err)
+
+	// 4. Verify metadata
+	snapData := sink.Bytes()
+	require.GreaterOrEqual(t, len(snapData), 16, "snapshot data too short for metadata")
+
+	restoredIndex := binary.BigEndian.Uint64(snapData[0:8])
+	restoredTerm := binary.BigEndian.Uint64(snapData[8:16])
+
+	assert.Equal(t, s.fsmIdx.Load(), restoredIndex, "snapshot index mismatch") // Should be 11
+	assert.Equal(t, s.fsmTerm.Load(), restoredTerm, "snapshot term mismatch")   // Should be 2
+
+
+	// 5. (Harder part) Verify data by loading into a new DB
+	snapshotDBContent := bytes.NewReader(snapData[16:]) // Skip metadata
+
+	restoreDBPath := t.TempDir()
+	restoredDB, err := db.Open(restoreDBPath)
+	require.NoError(t, err, "failed to open DB for restore validation")
+	defer restoredDB.Close()
+
+	// Load the snapshot content (actual DB backup part)
+	err = restoredDB.Load(snapshotDBContent, 256) // Using 256 as MaxPendingWrites
+	require.NoError(t, err, "failed to load snapshot data into new DB")
+
+	// Check if the original data is present
+	err = restoredDB.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(key))
+		require.NoError(t, err)
+		valBytes, err := item.ValueCopy(nil)
+		require.NoError(t, err)
+		assert.Equal(t, value, string(valBytes))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Release the snapshot (closes the pipe reader in our snapshot implementation)
+	fsmSnap.Release()
+}
+
+// Helper to create a minimal BadgerDB backup stream for testing restore
+func createMinimalBadgerBackup(t *testing.T, key, value string) []byte {
+	t.Helper()
+	tempDBPath := t.TempDir()
+	tempDB, err := db.Open(tempDBPath)
+	require.NoError(t, err)
+	defer tempDB.Close() // Ensure tempDB is closed to release resources
+
+	if key != "" && value != "" {
+		err = tempDB.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(key), []byte(value))
+		})
+		require.NoError(t, err)
+	}
+
+	var buf bytes.Buffer
+	_, err = tempDB.Backup(&buf, 0) // since=0 for full backup
+	require.NoError(t, err)
+	
+	// It's important to close the DB before its directory is removed by t.TempDir()
+	// If not closed properly, Badger might not flush everything or might hold locks.
+	err = tempDB.Close()
+	require.NoError(t, err)
+	
+	// Double check removal, sometimes TempDir might have issues if files are locked
+	// This is more of a sanity check for test stability than a requirement for the backup itself.
+	// On Windows, file locks can be particularly sticky.
+	// For this test, we assume t.TempDir() handles cleanup after tempDB.Close().
+
+	return buf.Bytes()
+}
+
+func TestStore_FSMInteraction_Restore(t *testing.T) {
+	s, cleanup := newTestStore(t, false) // Use file-based DB
+	defer cleanup()
+
+	// --- Prepare initial state for the store (will be wiped out by restore) ---
+	initialKey, initialValue := "initialkey", "initialvalue"
+	err := s.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(initialKey), []byte(initialValue))
+	})
+	require.NoError(t, err)
+	s.fsmIdx.Store(1) // Initial FSM state
+	s.fsmTerm.Store(1)
+
+	// --- Prepare snapshot data ---
+	restoreKey, restoreValue := "restorekey", "restorevalue"
+	snapIndex, snapTerm := uint64(10), uint64(2)
+
+	dbBackupData := createMinimalBadgerBackup(t, restoreKey, restoreValue)
+
+	var snapshotDataBuf bytes.Buffer
+	// Write metadata (index, term)
+	metaBytes := make([]byte, 16)
+	binary.BigEndian.PutUint64(metaBytes[0:8], snapIndex)
+	binary.BigEndian.PutUint64(metaBytes[8:16], snapTerm)
+	_, err = snapshotDataBuf.Write(metaBytes)
+	require.NoError(t, err)
+	// Write DB backup
+	_, err = snapshotDataBuf.Write(dbBackupData)
+	require.NoError(t, err)
+
+	// --- Call fsmRestore ---
+	// s.dbDir should be set by newTestStore if not using in-memory.
+	// If s.dbDir was not set, fsmRestore would use filepath.Join(s.raftDir, "badgerdb")
+	// Ensure the db path logic in fsmRestore aligns with how newTestStore sets up s.dbDir.
+	// For file-based, newTestStore sets s.dbDir.
+
+	err = s.fsmRestore(io.NopCloser(bytes.NewReader(snapshotDataBuf.Bytes())))
+	require.NoError(t, err)
+
+	// --- Verify restored state ---
+	assert.Equal(t, snapIndex, s.fsmIdx.Load(), "restored FSM index mismatch")
+	assert.Equal(t, snapTerm, s.fsmTerm.Load(), "restored FSM term mismatch")
+	assert.NotZero(t, s.fsmUpdateTime.Load(), "fsmUpdateTime should be set after restore")
+
+	// Verify new data is present
+	err = s.db.View(func(txn *badger.Txn) error {
+		item, errGet := txn.Get([]byte(restoreKey))
+		require.NoError(t, errGet, "restored key not found")
+		valBytes, errVal := item.ValueCopy(nil)
+		require.NoError(t, errVal)
+		assert.Equal(t, restoreValue, string(valBytes), "restored value mismatch")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Verify old data is gone
+	err = s.db.View(func(txn *badger.Txn) error {
+		_, errGet := txn.Get([]byte(initialKey))
+		assert.ErrorIs(t, errGet, badger.ErrKeyNotFound, "initial key should be gone after restore")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TODO: Add tests for Store.Query (basic GET) if not covered elsewhere
+// TODO: Add tests for Store.Execute (basic SET/DELETE via Raft Apply path) if not covered
+
+func TestStore_Query_SimpleGet(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	key, value := "querykey", "queryvalue"
+
+	// Set data using fsmApply (simulating data committed via Raft)
+	setStmt := fmt.Sprintf("SET %s %s", key, value)
+	setCmd := &commandProto.Command{
+		Type:       commandProto.Command_COMMAND_TYPE_EXECUTE,
+		SubCommand: command.MustMarshal(&commandProto.ExecuteRequest{Statements: []*commandProto.Statement{{Sql: setStmt}}}),
+	}
+	setLogData, err := command.Marshal(setCmd)
+	require.NoError(t, err)
+	s.fsmApply(&raft.Log{Index: 1, Term: 1, Data: setLogData})
+
+	// Query the data
+	queryReq := &commandProto.QueryRequest{
+		Statements: []*commandProto.Statement{{Sql: fmt.Sprintf("GET %s", key)}},
+	}
+	queryRows, err := s.Query(queryReq)
+	require.NoError(t, err)
+	require.Len(t, queryRows, 1, "expected one QueryRows result")
+	
+	result := queryRows[0]
+	require.Len(t, result.Columns, 2, "expected two columns")
+	assert.Equal(t, "key", result.Columns[0])
+	assert.Equal(t, "value", result.Columns[1])
+	
+	require.Len(t, result.Values, 1, "expected one row in values")
+	rowValue := result.Values[0]
+	require.Len(t, rowValue.Values, 2, "expected two datums in row")
+	
+	assert.Equal(t, key, rowValue.Values[0].GetS(), "key mismatch in query result")
+	assert.Equal(t, []byte(value), rowValue.Values[1].GetB(), "value mismatch in query result")
+}
+
+func TestStore_Query_KeyNotFound(t *testing.T) {
+	s, cleanup := newTestStore(t, true)
+	defer cleanup()
+
+	queryReq := &commandProto.QueryRequest{
+		Statements: []*commandProto.Statement{{Sql: "GET nonexistingkey"}},
+	}
+	queryRows, err := s.Query(queryReq)
+	require.NoError(t, err, "Query should not error for key not found")
+	require.Len(t, queryRows, 1)
+	assert.Empty(t, queryRows[0].Values, "expected no values for non-existing key")
+}


### PR DESCRIPTION
This commit introduces the core Finite State Machine (FSM) logic for the Raft-based store, enabling replicated state changes and snapshotting.

Key implementations:
- `Store.fsmApply`: Handles `COMMAND_TYPE_EXECUTE` for "SET key value" and "DELETE key" string commands, applying them to the BadgerDB. Also handles `COMMAND_TYPE_NOOP`. Other command types return `ErrNotImplemented` or a basic response.
- `snapshot.Snapshot.Persist`: Implements snapshot data persistence to a `raft.SnapshotSink`, including writing FSM index/term and the DB data stream.
- `Store.fsmSnapshot`: Creates snapshots of the BadgerDB, including FSM index/term metadata, and streams it via an `io.Pipe` to be consumed by Raft.
- `Store.fsmRestore`: Restores the store's state from a snapshot, including FSM index/term and BadgerDB data. Handles wiping the old DB directory and reloading into a new DB instance.
- `Store.Query` (Placeholder): Basic implementation for direct "GET key" reads from BadgerDB (does not go through Raft).
- Unit Tests: Added `internal/store/store_test.go` with tests for `fsmApply` (SET, DELETE, NOOP, invalid/unimplemented commands), snapshot creation/persistence, and snapshot restoration.

This provides the foundational mechanisms for distributed state management and data persistence in the store. Further work will be needed for more complex query capabilities through Raft and implementing other pending store functionalities.